### PR TITLE
feat: Añade tabla de puntuación T && método para borrar y recuperar enlaces de invitación

### DIFF
--- a/src/app/core/models/dtos/questionnaires/test-session-dto.ts
+++ b/src/app/core/models/dtos/questionnaires/test-session-dto.ts
@@ -5,5 +5,7 @@ export interface TestSessionDto {
     scholar_grade: number
     child_sex: string
     date_time_of_answer: string
+    token: string
+    isTokenValid: boolean
   }
   

--- a/src/app/core/services/questionnaires/questionnaires.service.ts
+++ b/src/app/core/services/questionnaires/questionnaires.service.ts
@@ -1,6 +1,6 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, catchError, map, of, throwError } from 'rxjs';
 import { InvitationLink } from '../../models/dtos/questionnaires/invitation-link';
 import { environment } from '../../../../environments/environment';
 import { TestSessionDto } from '../../models/dtos/questionnaires/test-session-dto';
@@ -29,4 +29,14 @@ export class QuestionnairesService {
     return this.http.get<TestResult>(url, { withCredentials: true });
   }
 
+  deleteTestSession(testId: number, psychologistCedula: string): Observable<boolean> {
+    const url = `${this.questionnariesUrl}/${psychologistCedula}/${testId}`;
+    return this.http.delete(url, { observe: 'response', withCredentials: true }).pipe(
+      map((response: HttpResponse<any>) => response.status === 200),
+      catchError((error: HttpErrorResponse) => {
+        alert('Error al eliminar el test' + error);
+        return of(false);
+      })
+    );
+  }
 }

--- a/src/app/modules/patients/components/patients-table/patients-table.component.html
+++ b/src/app/modules/patients/components/patients-table/patients-table.component.html
@@ -1,3 +1,5 @@
+<app-alert [message]="alertMessage" [type]="alertType" #alert> </app-alert>
+
 <div class="container mt-5">
   <div class="search-bar input-group">
     <span class="input-group-text"><i class="bi bi-search"></i></span>
@@ -20,6 +22,7 @@
         <th>Grado escolar</th>
         <th>Fecha del test</th>
         <th>Resultados</th>
+        <th>Acciones</th>
       </tr>
     </thead>
     <tbody id="patientTableBody">
@@ -41,16 +44,27 @@
               [routerLink]="['/cuestionario/resultado']"
               [queryParams]="{ testId: patient.test_id }"
             >
-              <i class="bi bi-eye fs-4"></i>
+              <i class="bi bi-eye fs-4" title="Ver resultados"></i>
             </a>
           </ng-container>
           <ng-template #noAnswer>
-            <span class="text-Secondary">Sin respuesta</span>
+            <span class="text-Secondary">Sin resultados</span>
           </ng-template>
+        </td>
+        <td>
+          <i
+            *ngIf="patient.isTokenValid && !patient.date_time_of_answer"
+            class="bi bi-link fs-4 me-4"
+            (click)="copyInvitationLink(patient.token)"
+            title="Copiar enlace de invitación"
+          ></i>
+          <i
+            class="bi bi-trash3 fs-5"
+            (click)="deleteTestSession(patient.test_id)"
+            title="Borrar test"
+          ></i>
         </td>
       </tr>
     </tbody>
   </table>
-
-
 </div>

--- a/src/app/modules/patients/components/patients-table/patients-table.component.ts
+++ b/src/app/modules/patients/components/patients-table/patients-table.component.ts
@@ -1,9 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { SessionService } from '../../../../core/services/auth/session.service';
 import { RouterLink } from '@angular/router';
 import { TestSessionDto } from '../../../../core/models/dtos/questionnaires/test-session-dto';
 import { QuestionnairesService } from '../../../../core/services/questionnaires/questionnaires.service';
+import { environment } from '../../../../../environments/environment';
+import { AlertComponent } from '../../../../shared/components/alert/alert.component';
 
 interface Patient {
   nombre: string;
@@ -16,14 +18,17 @@ interface Patient {
 @Component({
   selector: 'app-patients-table',
   standalone: true,
-  imports: [CommonModule, RouterLink],
   templateUrl: './patients-table.component.html',
   styleUrl: './patients-table.component.scss',
+  imports: [CommonModule, RouterLink, AlertComponent],
 })
 export class PatientsTableComponent implements OnInit {
   patients: TestSessionDto[] = [];
   filteredPatients: TestSessionDto[] = [];
   private _psychologistCedula = '';
+  alertMessage: string | null = null;
+  alertType: 'success' | 'danger' = 'danger';
+  @ViewChild('alert') alert!: AlertComponent;
 
   constructor(
     private sessionService: SessionService,
@@ -33,7 +38,6 @@ export class PatientsTableComponent implements OnInit {
   ngOnInit(): void {
     this._psychologistCedula = this.sessionService.userData?.cedula ?? '';
     this.getPatients();
-    
   }
 
   scholarGradeMap: { [key: number]: string } = {
@@ -50,8 +54,6 @@ export class PatientsTableComponent implements OnInit {
         next: (data) => {
           this.patients = data;
           this.filteredPatients = this.patients;
-
-          console.log('Resultados:', data);
         },
         error: (error) => {
           console.log('Error al obtener los resultados:', error);
@@ -88,6 +90,45 @@ export class PatientsTableComponent implements OnInit {
 
     return `${day} ${month} ${year} - ${hours}:${minutes}`;
   }
-  
-  
+
+  copyInvitationLink(testToken: string): void {
+    const invitationLink = `${environment.gameUrl}/?token=${testToken}`;
+    navigator.clipboard
+      .writeText(invitationLink)
+      .then(() => {
+        this.alertMessage = 'Enlace copiado al portapapeles';
+        this.alertType = 'success';
+        this.alert.showAlert();
+      })
+      .catch((err) => {
+        this.alertMessage = 'Error al copiar el enlace ' + err.message;
+        this.alertType = 'danger';
+        this.alert.showAlert();
+      });
+  }
+
+  deleteTestSession(testId: number): void {
+    if (!confirm('¿Seguro que quieres borrar este test?')) return;
+    this.questionnariesService
+      .deleteTestSession(testId, this._psychologistCedula)
+      .subscribe({
+        next: (success) => {
+          if (success) {
+            this.getPatients();
+            this.alertMessage = 'Test borrado con éxito';
+            this.alertType = 'success';
+            this.alert.showAlert();
+          } else {
+            this.alertMessage = 'Error al borrar el test';
+            this.alertType = 'danger';
+            this.alert.showAlert();
+          }
+        },
+        error: (error) => {
+          this.alertMessage = 'Error al borrar el test: ' + error.message;
+          this.alertType = 'danger';
+          this.alert.showAlert();
+        },
+      });
+  }
 }

--- a/src/app/modules/questionnaires/components/t-index-result/t-index-result/t-index-result.component.html
+++ b/src/app/modules/questionnaires/components/t-index-result/t-index-result/t-index-result.component.html
@@ -1,0 +1,136 @@
+<div
+  class="card bg-Secondary shadow-sm d-flex justify-content-center align-items-center px-3 py-3"
+>
+  <table class="table table-striped table-responsive text-center">
+    <tr class="text-Primary">
+      <th></th>
+      <th>DFS</th>
+      <th>TOT</th>
+      <th>FIS</th>
+      <th>INQ</th>
+      <th>SOC</th>
+    </tr>
+    <tr class="py-3 border-bottom">
+      <td class="fw-bold">Puntuación natural</td>
+      <td id="dfs" class="">{{ testResults?.defensiveness_index ?? 0 }}</td>
+      <td id="tot">{{ testResults?.total_anxiety_index ?? 0 }}</td>
+      <td id="fis">{{ testResults?.physiological_anxiety_index ?? 0 }}</td>
+      <td id="inq">{{ testResults?.worry_index ?? 0 }}</td>
+      <td id="soc">{{ testResults?.social_anxiety_index ?? 0 }}</td>
+    </tr>
+    <tr class="py-3">
+      <td class="fw-bold">Puntuación T</td>
+      <td
+        id="t-dfs"
+        [ngClass]="{
+          'bg-Success': tDefScore <= 39,
+          'text-light': tDefScore > 39,
+          'bg-Info': tDefScore <= 60 && tDefScore >= 40,
+          'bg-Warning': tDefScore <= 61 && tDefScore >= 70,
+          'bg-Danger': tDefScore > 71
+        }"
+      >
+        {{ tDefScore }}
+      </td>
+      <td
+        id="t-tot"
+        [ngClass]="{
+          'bg-Success': tTotScore <= 39,
+          'text-light': tTotScore > 39,
+          'bg-Info': tTotScore <= 60 && tTotScore >= 40,
+          'bg-Warning': tTotScore <= 61 && tTotScore >= 70,
+          'bg-Danger': tTotScore > 71
+        }"
+      >
+        {{ tTotScore }}
+      </td>
+      <td
+        id="t-fis"
+        [ngClass]="{
+          'bg-Success': tFisScore <= 39,
+          'text-light': tFisScore > 39,
+          'bg-Info': tFisScore <= 60 && tFisScore >= 40,
+          'bg-Warning': tFisScore <= 61 && tFisScore >= 70,
+          'bg-Danger': tFisScore > 71
+        }"
+      >
+        {{ tFisScore }}
+      </td>
+      <td
+        id="t-inq"
+        [ngClass]="{
+          'bg-Success': tInqScore <= 39,
+          'text-light': tInqScore > 39,
+          'bg-Info': tInqScore <= 60 && tInqScore >= 40,
+          'bg-Warning': tInqScore <= 61 && tInqScore >= 70,
+          'bg-Danger': tInqScore > 71
+        }"
+      >
+        {{ tInqScore }}
+      </td>
+      <td
+        id="t-soc"
+        [ngClass]="{
+          'bg-Success': tSocScore <= 39,
+          'text-light': tSocScore > 39,
+          'bg-Info': tSocScore <= 60 && tSocScore >= 40,
+          'bg-Warning': tSocScore <= 61 && tSocScore >= 70,
+          'bg-Danger': tSocScore > 71
+        }"
+      >
+        {{ tSocScore }}
+      </td>
+    </tr>
+  </table>
+  <div
+    id="descriptions"
+    class="text-Primary d-flex flex-column w-100 ps-4 mt-2 bg-Secondary"
+  >
+    <span class="fw-bold">Descriptores de la puntuación T:</span>
+    <div class="row my-1 ps-3">
+      <input
+        type="radio"
+        id="success"
+        class="bg-Success col-2"
+        checked
+        disabled
+      />
+      <label for="success" class="col-10 text-description"
+        >Menos problemático que para la mayoría de los estudiantes (Menos de
+        40).</label
+      >
+    </div>
+    <div class="row my-1 ps-3">
+      <input type="radio" id="info" class="bg-Info col-2" checked disabled />
+      <label for="info" class="col-10 text-description"
+        >Menos problemático que para la mayoría de los estudiantes (Entre 40 y
+        60).</label
+      >
+    </div>
+    <div class="row my-1 ps-3">
+      <input
+        type="radio"
+        id="warning"
+        class="bg-Warning col-2"
+        checked
+        disabled
+      />
+      <label for="warning" class="col-10 text-description"
+        >Moderadamente problemático (Entre 61 y 70).</label
+      >
+      <span></span>
+    </div>
+    <div class="row ps-3">
+      <input
+        type="radio"
+        id="danger"
+        class="bg-Danger col-2"
+        checked
+        disabled
+      />
+      <label for="danger" class="col-10 text-description"
+        >Extremadamente problemático (71 o más).</label
+      >
+    </div>
+  </div>
+</div>

--- a/src/app/modules/questionnaires/components/t-index-result/t-index-result/t-index-result.component.scss
+++ b/src/app/modules/questionnaires/components/t-index-result/t-index-result/t-index-result.component.scss
@@ -1,0 +1,8 @@
+.card{
+    border: 0px;
+    border-radius: 20px;
+}
+
+.text-description{
+    font-size: 12px;
+}

--- a/src/app/modules/questionnaires/components/t-index-result/t-index-result/t-index-result.component.ts
+++ b/src/app/modules/questionnaires/components/t-index-result/t-index-result/t-index-result.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { TestResults } from '../../../../../core/models/dtos/questionnaires/test-result-dto';
+import { AnxietyScoreService } from '../../../../../core/services/results_analisis/t-score.service';
+import {  NgClass } from '@angular/common';
+
+@Component({
+  selector: 'app-t-index-result',
+  standalone: true,
+  templateUrl: './t-index-result.component.html',
+  styleUrls: ['./t-index-result.component.scss'],
+  imports: [NgClass],
+})
+export class TIndexResultComponent implements OnInit {
+  tDefScore: number = 0;
+  tFisScore: number = 0;
+  tInqScore: number = 0;
+  tSocScore: number = 0;
+  tTotScore: number = 0;
+  testResults?: TestResults;
+
+  @Input() set results(value: TestResults | undefined) {
+    if (value) {
+      this.testResults = value;
+      this.tDefScore =
+        this.tIndexService.getTScore(1, value.defensiveness_index) ?? 0;
+      this.tFisScore =
+        this.tIndexService.getTScore(
+          2,
+          value.physiological_anxiety_index,
+        ) ?? 0;
+      this.tInqScore =
+        this.tIndexService.getTScore(3, value.worry_index) ?? 0;
+      this.tSocScore =
+        this.tIndexService.getTScore(4, value.social_anxiety_index) ?? 0;
+      this.tTotScore =
+        this.tIndexService.getTScore(5, value.total_anxiety_index) ?? 0;
+    }
+  }
+
+  constructor(private tIndexService: AnxietyScoreService) {}
+
+  ngOnInit(): void {
+
+  }	
+}

--- a/src/app/modules/questionnaires/pages/new-questionnarie/new-questionnarie.component.html
+++ b/src/app/modules/questionnaires/pages/new-questionnarie/new-questionnarie.component.html
@@ -1,10 +1,15 @@
+<app-alert [message]="alertMessage" [type]="alertType" #alert> </app-alert>
+
 <div class="content">
   <p class="text-Primary fs-4"><strong>Generación de Test CMASR-2</strong></p>
 
-  <app-questionnarie-form (formSubmitted)="onFormSubmitted($event)"></app-questionnarie-form>
+  <app-questionnarie-form
+    (formSubmitted)="onFormSubmitted($event)"
+  ></app-questionnarie-form>
 
-  <app-link-modal *ngIf="isModalVisible" (close)="onCloseContainer()" [link]="link"></app-link-modal>
-  
+  <app-link-modal
+    *ngIf="isModalVisible"
+    (close)="onCloseContainer()"
+    [link]="link"
+  ></app-link-modal>
 </div>
- 
-

--- a/src/app/modules/questionnaires/pages/new-questionnarie/new-questionnarie.component.ts
+++ b/src/app/modules/questionnaires/pages/new-questionnarie/new-questionnarie.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { QuestionnarieFormComponent } from '../../components/questionnarie-form/questionnarie-form.component';
-import { Router, RouterOutlet } from '@angular/router';
+import {  RouterOutlet } from '@angular/router';
 import { LinkModalComponent } from '../../components/link-modal/link-modal.component';
 import { CommonModule } from '@angular/common';
 import { QuestionnairesService } from '../../../../core/services/questionnaires/questionnaires.service';
@@ -8,29 +8,34 @@ import { Observable, switchMap } from 'rxjs';
 import { CreatePatientDto } from '../../../../core/models/dtos/patients/CreatePatientDto';
 import { PatientsService } from '../../../../core/services/patients/patients.service';
 import { SessionService } from '../../../../core/services/auth/session.service';
+import { AlertComponent } from "../../../../shared/components/alert/alert.component";
 
 @Component({
-  selector: 'app-new-questionnarie',
-  standalone: true,
-  imports: [
-    RouterOutlet,
-    QuestionnarieFormComponent,
-    LinkModalComponent,
-    CommonModule,
-  ],
-  templateUrl: './new-questionnarie.component.html',
-  styleUrl: './new-questionnarie.component.scss',
+    selector: 'app-new-questionnarie',
+    standalone: true,
+    templateUrl: './new-questionnarie.component.html',
+    styleUrl: './new-questionnarie.component.scss',
+    imports: [
+        RouterOutlet,
+        QuestionnarieFormComponent,
+        LinkModalComponent,
+        CommonModule,
+        AlertComponent
+    ]
 })
 export class NewQuestionnarieComponent implements OnInit {
   isModalVisible = false;
   link = '';
   private _psychologistCedula = '';
+  alertMessage: string | null = null;
+  alertType: 'success' | 'danger' = 'danger';
+  @ViewChild('alert') alert!: AlertComponent;
+
 
   constructor(
     private questionnariesService: QuestionnairesService,
     private patientsService: PatientsService,
     private sessionService: SessionService,
-    private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -43,6 +48,10 @@ export class NewQuestionnarieComponent implements OnInit {
       .addChild(this._psychologistCedula, patient)
       .pipe(
         switchMap((childId) => {
+          this.alertMessage = 'Test CMASR-2 creado con éxito';
+          this.alertType = 'success';
+          this.alert.showAlert();
+          // Get invitation link
           return this.getLink(childId);
         }),
       )

--- a/src/app/modules/questionnaires/pages/questionnarie-result/questionnarie-result.component.html
+++ b/src/app/modules/questionnaires/pages/questionnarie-result/questionnarie-result.component.html
@@ -6,7 +6,7 @@
     [patientData]="patientInfo"
   ></app-patient-info>
 
-  <div class="container mt-2">
+  <div class="container mt-2 h-auto">
     <div class="row">
       <div id="questions-responses" class="col bg-Secondary shadow-sm py-3">
         <p class="text-Primary">Seleccione la clasificación de preguntas:</p>
@@ -50,10 +50,14 @@
           <app-result [results]="anxietyIndex"></app-result>
         </div>
         <!-- Inconsistencies questions -->
-        <div id="inconsistencies" class="row">
+        <div id="inconsistencies" class="row mb-1">
           <app-inconsistent-responses
             [inconsistentResponses]="inconsistentQuestions"
           ></app-inconsistent-responses>
+        </div>
+        <!-- T-index result -->
+        <div id="t-index" class="row">
+          <app-t-index-result [results]="anxietyIndex"></app-t-index-result>
         </div>
       </div>
     </div>

--- a/src/app/modules/questionnaires/pages/questionnarie-result/questionnarie-result.component.scss
+++ b/src/app/modules/questionnaires/pages/questionnarie-result/questionnarie-result.component.scss
@@ -1,9 +1,9 @@
 .questions-container {
-    height: auto;
-    max-height: 550px;
+    height: 850px;
     overflow-y: auto;
 }
 
 #questions-responses {
     border-radius: 20px;
+    height: auto;
 }

--- a/src/app/modules/questionnaires/pages/questionnarie-result/questionnarie-result.component.ts
+++ b/src/app/modules/questionnaires/pages/questionnarie-result/questionnarie-result.component.ts
@@ -18,6 +18,7 @@ import {
   InconsistentResponsesDTO,
   Pairs,
 } from '../../../../core/models/dtos/questionnaires/inconsistent-responses-dto';
+import { TIndexResultComponent } from '../../components/t-index-result/t-index-result/t-index-result.component';
 
 @Component({
   selector: 'app-questionnarie-result',
@@ -28,6 +29,7 @@ import {
     QuestionComponent,
     CommonModule,
     InconsistentResponsesComponent,
+    TIndexResultComponent
   ],
   templateUrl: './questionnarie-result.component.html',
   styleUrl: './questionnarie-result.component.scss',
@@ -94,9 +96,7 @@ export class QuestionnarieResultComponent implements OnInit {
 
             // Set inconsistent questions
             this.getInconsistencies();
-            console.log(this.answers[0].value);
-            console.log( this.answers[48].value );
-            console.log( this.answers[49].value );
+
           });
       } else {
         alert('No se encontró el test');

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -1,0 +1,4 @@
+<div class="alert" [ngClass]="type" *ngIf="show">
+  <!--<span class="closebtn" (click)="closeAlert()">&times;</span> -->
+  {{ message }}
+</div>

--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, SimpleChanges } from '@angular/core';
+
+@Component({
+  selector: 'app-alert',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './alert.component.html',
+  styleUrl: './alert.component.scss',
+})
+export class AlertComponent {
+  @Input() message: string | null = null;
+  @Input() type: 'success' | 'danger' = 'danger';
+  show = false;
+  timeoutId: any;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['message'] && this.message) {
+      this.showAlert();
+    }
+  }
+
+  closeAlert(): void {
+    this.show = false;
+    this.message = null;
+    clearTimeout(this.timeoutId); 
+  }
+
+  showAlert(): void {
+    this.show = true;
+      clearTimeout(this.timeoutId); 
+      this.timeoutId = setTimeout(() => {
+        this.show = false;
+      }, 3000);
+  }
+}

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -20,7 +20,6 @@
   }
 
 header{
-    width: 100vw;
     height: 8vh; 
     display: flex; 
     flex-direction: row;

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: 'http://127.0.0.1:8000',
+  gameUrl: 'http:127.0.0.1:8060',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '${BACKEND_WEB_APP_API}',
+  gameUrl: '${BACKEND_GAME_API}'
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -358,3 +358,39 @@ input[type="radio"] {
 .info-icon:hover .info-text {
   display: block;
 }
+
+/* Alert Styles */
+.alert {
+  padding: 20px;
+  background-color: $danger-color;
+  color: $light-color;
+  font-weight: bold;
+  margin-bottom: 15px;
+
+  &.success {
+    background-color: $success-color;
+  }
+
+  &.info {
+    background-color: $info-color;
+  }
+
+  &.warning {
+    background-color: $warning-color;
+  }
+
+  .closebtn {
+    margin-left: 15px;
+    color: white;
+    font-weight: bold;
+    float: right;
+    font-size: 22px;
+    line-height: 20px;
+    cursor: pointer;
+    transition: 0.3s;
+
+    &:hover {
+      color: black;
+    }
+  }
+}


### PR DESCRIPTION
# Resumen:

Este PR implementa la lógica en el frontend del Sistema Hedan, misma que incluye métodos para eliminar sesiones de test, almacenar tokens y ver enlaces de puntuación T. 

## Detalles técnicos:

### Lista de pacientes
- Se añaden opciones para borrar sesiones de test o ver enlaces de invitación. 
- Se valida la existencia de respuestas para cada sesión creada. 

### Resultados individuales: 
- Se añade una tabla con la puntuación T correspondiente a cada índice de ansiedad. 
- Se añade una descripción de cada puntuación T 

## Capturas de pantalla: 
- Lista de pacientes.
![image](https://github.com/TIC-LPQS-2023B-2024A/hedan-web-app/assets/78981969/c3ae04d0-919d-4166-be0a-f55165c66c64)

- Resultados individuales.
![image](https://github.com/TIC-LPQS-2023B-2024A/hedan-web-app/assets/78981969/de88fb51-1f85-44f9-8169-473fb031d0a1)

